### PR TITLE
Fix the markdown link syntax

### DIFF
--- a/Arrays/one-d.md
+++ b/Arrays/one-d.md
@@ -5,7 +5,7 @@
 + Indexed Acces
 
 ## Actions
-+ [access](./spec#Access)
-+ [obverse](./spec#Obverse)
-+ [reverse](./spec#Reverse)
-+ [traverse](./spec#Traverse)
++ [access](./spec.md#access)
++ [obverse](./spec.md#obverse)
++ [reverse](./spec.md#reverse)
++ [traverse](./spec.md#traverse)


### PR DESCRIPTION
Links in one-d.md didn't work before, should work now.